### PR TITLE
Add flake for NixOS

### DIFF
--- a/.github/workflows/build_nix.yml
+++ b/.github/workflows/build_nix.yml
@@ -1,0 +1,12 @@
+name: "Test and build NixOS package"
+on:
+  pull_request:
+  push:
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v19
+    - run: nix build
+    - run: nix flake check

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+result

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ The layout namespace (for now) is always `luatile`.
 
 <https://aur.archlinux.org/packages/river-luatile-git>
 
+### NixOS
+
+Use the provided flake package or overlay.
+
 ### Manually from source
 
 ```sh

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,24 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1679262748,
+        "narHash": "sha256-DQCrrAFrkxijC6haUzOC5ZoFqpcv/tg2WxnyW3np1Cc=",
+        "path": "/nix/store/y34pw71w25ay4j5bm5239m8gw0pp4w63-source",
+        "rev": "60c1d71f2ba4c80178ec84523c2ca0801522e0a6",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,62 @@
+{
+  description = "Write your own river layout generator in lua";
+
+  outputs = { self, nixpkgs }:
+    let
+
+      # to work with older version of flakes
+      lastModifiedDate = self.lastModifiedDate or self.lastModified or "19700101";
+
+      # Generate a user-friendly version number.
+      version = "${builtins.substring 0 8 lastModifiedDate}-${self.shortRev or "dirty"}";
+
+      # System types to support.
+      supportedSystems = [ "x86_64-linux" ];
+
+      # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
+      forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
+
+      # Nixpkgs instantiated for supported system types.
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; overlays = [ self.overlay ]; });
+
+    in
+    {
+
+      # A Nixpkgs overlay.
+      overlay = final: prev: with final; {
+
+        river-luatile = pkgs.rustPlatform.buildRustPackage {
+          pname = "river-luatile";
+          inherit version;
+          src = ./.;
+
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+            outputHashes = {
+              "river-layout-toolkit-0.1.0" = "sha256-ctI0n4Jwf1oMjmGf1Lsko1CHfOQTTphCH4Ona3aHXj4=";
+              "wayrs-client-0.1.0" = "sha256-94URrCTfBfub2TE00/9fmbs1opnIBsBsa0m3oIJRtm4=";
+            };
+          };
+
+          buildInputs = with pkgs; [luajit ];
+          nativeBuildInputs = with pkgs; [pkg-config ];
+          PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig";
+        };
+      };
+
+      # Provide some binary packages for selected system types.
+      packages = forAllSystems (system:
+        {
+          inherit (nixpkgsFor.${system}) river-luatile;
+        });
+
+      # The default package for 'nix build'. This makes sense if the
+      # flake provides only one package or there is a clear "main"
+      # package.
+      defaultPackage = forAllSystems (system: self.packages.${system}.river-luatile);
+
+      # Provide a 'nix develop' environment for interactive hacking.
+      devShell = forAllSystems (system: self.packages.${system}.river-luatile);
+
+    };
+}


### PR DESCRIPTION
Add a flake to make it easy to build and develop this on NixOS. 

The flake adds a package (`nix build`), an overlay and a development shell (`nix develop`) as per the default flake template.
I also included the default GitHub action template for Nix, which will test and build the package on new commits.

With nix installed this also allows to run river-luatile from anywhere using `nix run "github:MaxVerevkin/river-luatile`